### PR TITLE
Rename query parameter to allow_reversed

### DIFF
--- a/API_REST_OPTIMIZATION.md
+++ b/API_REST_OPTIMIZATION.md
@@ -55,7 +55,7 @@ This API's primary function is to take a word and return all possible ways to sp
 
 ### 5. New Feature: Reversed Symbols
 
-The API now supports a `reverse=true` query parameter that reverses all two-letter element symbols:
+The API now supports an `allow_reversed=true` query parameter that allows reversed two-letter element symbols:
 - `He` → `eH`
 - `Li` → `iL` 
 - `Ne` → `eN`
@@ -63,7 +63,7 @@ The API now supports a `reverse=true` query parameter that reverses all two-lett
 
 **Example:**
 ```bash
-GET /api/v1/words/hello/combinations?reverse=true
+GET /api/v1/words/hello/combinations?allow_reversed=true
 ```
 
 ### 6. Comprehensive Error Handling
@@ -92,7 +92,7 @@ GET /api/v1/words/hero/combinations
 # Returns: H-Er-O (Hydrogen-Erbium-Oxygen)
 
 # With reversed symbols
-GET /api/v1/words/hero/combinations?reverse=true
+GET /api/v1/words/hero/combinations?allow_reversed=true
 # Uses: H, rE (reversed Er), O for different possibilities
 ```
 

--- a/API_REST_OPTIMIZATION.md
+++ b/API_REST_OPTIMIZATION.md
@@ -55,7 +55,7 @@ This API's primary function is to take a word and return all possible ways to sp
 
 ### 5. New Feature: Reversed Symbols
 
-The API now supports an `allow_reversed=true` query parameter that allows reversed two-letter element symbols:
+The API now supports an `allow_reversed_symbols=true` query parameter that allows reversed two-letter element symbols:
 - `He` → `eH`
 - `Li` → `iL` 
 - `Ne` → `eN`
@@ -63,7 +63,7 @@ The API now supports an `allow_reversed=true` query parameter that allows revers
 
 **Example:**
 ```bash
-GET /api/v1/words/hello/combinations?allow_reversed=true
+GET /api/v1/words/hello/combinations?allow_reversed_symbols=true
 ```
 
 ### 6. Comprehensive Error Handling
@@ -92,7 +92,7 @@ GET /api/v1/words/hero/combinations
 # Returns: H-Er-O (Hydrogen-Erbium-Oxygen)
 
 # With reversed symbols
-GET /api/v1/words/hero/combinations?allow_reversed=true
+GET /api/v1/words/hero/combinations?allow_reversed_symbols=true
 # Uses: H, rE (reversed Er), O for different possibilities
 ```
 

--- a/main.py
+++ b/main.py
@@ -117,7 +117,7 @@ def api_documentation():
                 <strong>Path Parameters:</strong><br>
                 • <code>word</code>: The word to analyze (max 50 characters, alphabetic only)<br><br>
                 <strong>Query Parameters:</strong><br>
-                • <code>reverse</code> (optional): Set to "true" to reverse two-letter element symbols (He→eH, Li→iL, etc.)
+                • <code>allow_reversed</code> (optional): Set to "true" to allow reversed two-letter element symbols (He→eH, Li→iL, etc.)
             </div>
         </div>
         
@@ -134,7 +134,7 @@ def api_documentation():
         <h2>Examples</h2>
         <ul>
             <li><code>GET /api/v1/words/hero/combinations</code> → H-Er-O</li>
-            <li><code>GET /api/v1/words/hero/combinations?reverse=true</code> → Use reversed symbols (eH, rE, O)</li>
+            <li><code>GET /api/v1/words/hero/combinations?allow_reversed=true</code> → Use reversed symbols (eH, rE, O)</li>
         </ul>
         
         <h2>Response Format</h2>
@@ -213,7 +213,7 @@ def get_word_combinations(word):
         return create_error_response("MISSING_WORD", "Word parameter is required")
     
     # Check for reverse symbols option
-    reverse_symbols = request.query.get('reverse', '').lower() == 'true'
+    reverse_symbols = request.query.get('allow_reversed', '').lower() == 'true'
     
     # Sanitize input: remove non-alphabetic characters
     clean_word = ''.join(c for c in word if c.isalpha())

--- a/main.py
+++ b/main.py
@@ -117,7 +117,7 @@ def api_documentation():
                 <strong>Path Parameters:</strong><br>
                 • <code>word</code>: The word to analyze (max 50 characters, alphabetic only)<br><br>
                 <strong>Query Parameters:</strong><br>
-                • <code>allow_reversed</code> (optional): Set to "true" to allow reversed two-letter element symbols (He→eH, Li→iL, etc.)
+                • <code>allow_reversed_symbols</code> (optional): Set to "true" to allow reversed two-letter element symbols (He→eH, Li→iL, etc.)
             </div>
         </div>
         
@@ -134,7 +134,7 @@ def api_documentation():
         <h2>Examples</h2>
         <ul>
             <li><code>GET /api/v1/words/hero/combinations</code> → H-Er-O</li>
-            <li><code>GET /api/v1/words/hero/combinations?allow_reversed=true</code> → Use reversed symbols (eH, rE, O)</li>
+            <li><code>GET /api/v1/words/hero/combinations?allow_reversed_symbols=true</code> → Use reversed symbols (eH, rE, O)</li>
         </ul>
         
         <h2>Response Format</h2>
@@ -213,7 +213,7 @@ def get_word_combinations(word):
         return create_error_response("MISSING_WORD", "Word parameter is required")
     
     # Check for reverse symbols option
-    reverse_symbols = request.query.get('allow_reversed', '').lower() == 'true'
+    reverse_symbols = request.query.get('allow_reversed_symbols', '').lower() == 'true'
     
     # Sanitize input: remove non-alphabetic characters
     clean_word = ''.join(c for c in word if c.isalpha())


### PR DESCRIPTION
Rename query parameter `reverse` to `allow_reversed_symbols` to accurately reflect its function of allowing reversed two-letter element symbols.