### PR TITLE
Allow additive reversed symbol usage

### DIFF
--- a/API_REST_OPTIMIZATION.md
+++ b/API_REST_OPTIMIZATION.md
@@ -55,10 +55,10 @@ This API's primary function is to take a word and return all possible ways to sp
 
 ### 5. New Feature: Reversed Symbols
 
-The API now supports an `allow_reversed_symbols=true` query parameter that allows reversed two-letter element symbols:
-- `He` → `eH`
-- `Li` → `iL` 
-- `Ne` → `eN`
+The API now supports an `allow_reversed_symbols=true` query parameter that allows both normal and reversed two-letter element symbols:
+- `He` is available as both `He` and `eH`
+- `Li` is available as both `Li` and `iL` 
+- `Ne` is available as both `Ne` and `eN`
 - Single letters (H, B, C, etc.) remain unchanged
 
 **Example:**

--- a/main.py
+++ b/main.py
@@ -56,17 +56,18 @@ def set_json_headers():
     set_cors_headers()
 
 def get_available_symbols(reverse_symbols=False):
-    """Get list of available element symbols, optionally reversed"""
+    """Get list of available element symbols, optionally including reversed"""
     if not reverse_symbols:
         return ELEMENT_SYMBOLS
     
-    # Create list with reversed two-letter symbols
-    symbols = []
+    # Create list with both normal and reversed two-letter symbols
+    symbols = list(ELEMENT_SYMBOLS)  # Start with all normal symbols
     for symbol in ELEMENT_SYMBOLS:
         if len(symbol) == 2:
-            symbols.append(symbol[::-1])  # Reverse two-letter symbols
-        else:
-            symbols.append(symbol)  # Keep single-letter symbols as is
+            reversed_symbol = symbol[::-1]
+            # Only add if it's not the same as the original (prevents duplicates)
+            if reversed_symbol != symbol:
+                symbols.append(reversed_symbol)
     return symbols
 
 @app.hook('after_request')
@@ -118,7 +119,7 @@ def api_documentation():
                 <strong>Path Parameters:</strong><br>
                 • <code>word</code>: The word to analyze (max 50 characters, alphabetic only)<br><br>
                 <strong>Query Parameters:</strong><br>
-                • <code>allow_reversed_symbols</code> (optional): Set to "true" to allow reversed two-letter element symbols (He→eH, Li→iL, etc.)
+                • <code>allow_reversed_symbols</code> (optional): Set to "true" to allow both normal and reversed two-letter element symbols (He+eH, Li+iL, etc.)
             </div>
         </div>
         
@@ -150,7 +151,7 @@ def api_documentation():
         <h2>Examples</h2>
         <ul>
             <li><code>GET /api/v1/words/hero/combinations</code> → H-Er-O</li>
-            <li><code>GET /api/v1/words/hero/combinations?allow_reversed_symbols=true</code> → Use reversed symbols (eH, rE, O)</li>
+            <li><code>GET /api/v1/words/hero/combinations?allow_reversed_symbols=true</code> → Use both normal and reversed symbols (He+eH, etc.)</li>
         </ul>
         
         <h2>Response Format</h2>

--- a/openapi.json
+++ b/openapi.json
@@ -248,7 +248,7 @@
             "name": "allow_reversed_symbols",
             "in": "query",
             "required": false,
-            "description": "Allow reversed two-letter element symbols (e.g., He\u2192eH, Li\u2192iL).\nSingle-letter symbols remain unchanged.\n",
+            "description": "Allow both normal and reversed two-letter element symbols (e.g., He+eH, Li+iL).\nSingle-letter symbols remain unchanged.\n",
             "schema": {
               "type": "boolean",
               "default": false,
@@ -282,7 +282,7 @@
                               "properties": {
                                 "reverse_symbols": {
                                   "type": "boolean",
-                                  "description": "Whether reversed symbols were used"
+                                  "description": "Whether both normal and reversed symbols were used"
                                 }
                               }
                             }
@@ -335,7 +335,7 @@
                     }
                   },
                   "hero_reversed": {
-                    "summary": "Combinations with reversed symbols",
+                    "summary": "Combinations with both normal and reversed symbols",
                     "value": {
                       "data": {
                         "input_word": "hero",
@@ -839,7 +839,7 @@
         "name": "allow_reversed_symbols",
         "in": "query",
         "required": false,
-        "description": "Allow reversed two-letter element symbols",
+        "description": "Allow both normal and reversed two-letter element symbols",
         "schema": {
           "type": "boolean",
           "default": false

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -182,7 +182,7 @@ paths:
           in: query
           required: false
           description: |
-            Allow reversed two-letter element symbols (e.g., He→eH, Li→iL).
+            Allow both normal and reversed two-letter element symbols (e.g., He+eH, Li+iL).
             Single-letter symbols remain unchanged.
           schema:
             type: boolean
@@ -207,7 +207,7 @@ paths:
                             properties:
                               reverse_symbols:
                                 type: boolean
-                                description: Whether reversed symbols were used
+                                description: Whether both normal and reversed symbols were used
               examples:
                 hero_standard:
                   summary: Standard combinations for "hero"
@@ -233,7 +233,7 @@ paths:
                       timestamp: "2023-01-01T00:00:00Z"
                       version: "v1"
                 hero_reversed:
-                  summary: Combinations with reversed symbols
+                  summary: Combinations with both normal and reversed symbols
                   value:
                     data:
                       input_word: "hero"


### PR DESCRIPTION
Make `allow_reversed_symbols` additive to include both normal and reversed two-letter symbols.