### PR TITLE
Remove /combinations from main endpoint

### DIFF
--- a/API_REST_OPTIMIZATION.md
+++ b/API_REST_OPTIMIZATION.md
@@ -49,7 +49,7 @@ This API's primary function is to take a word and return all possible ways to sp
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/api/v1/words/{word}/combinations` | **Primary:** Find element combinations for a word |
+| GET | `/api/v1/words/{word}` | **Primary:** Find element combinations for a word |
 | GET | `/api/v1/elements` | Get all chemical elements (reference data) |
 | GET | `/api/v1/elements/{symbol}` | Get specific element |
 
@@ -63,7 +63,7 @@ The API now supports an `allow_reversed_symbols=true` query parameter that allow
 
 **Example:**
 ```bash
-GET /api/v1/words/hello/combinations?allow_reversed_symbols=true
+GET /api/v1/words/hello?allow_reversed_symbols=true
 ```
 
 ### 6. Comprehensive Error Handling
@@ -88,11 +88,11 @@ GET /api/v1/words/hello/combinations?allow_reversed_symbols=true
 ### Primary Use Case: Word Combinations
 ```bash
 # Standard combinations
-GET /api/v1/words/hero/combinations
+GET /api/v1/words/hero
 # Returns: H-Er-O (Hydrogen-Erbium-Oxygen)
 
 # With reversed symbols
-GET /api/v1/words/hero/combinations?allow_reversed_symbols=true
+GET /api/v1/words/hero?allow_reversed_symbols=true
 # Uses: H, rE (reversed Er), O for different possibilities
 ```
 
@@ -160,7 +160,7 @@ GET /api/v1/elements/H
 
 ## Migration from Previous Version
 
-- **Old**: `/word/<word>` → **New**: `/api/v1/words/<word>/combinations`
+- **Old**: `/word/<word>` → **New**: `/api/v1/words/<word>`
 - **Old**: `/elements` → **New**: `/api/v1/elements`
 - **Removed**: `/symbols` (symbols included in elements data)
 

--- a/OPENAPI_SPEC.md
+++ b/OPENAPI_SPEC.md
@@ -15,7 +15,7 @@ The Element Words API converts words into chemical element symbol combinations. 
 
 ### Key Features Documented
 
-1. **Primary Endpoint**: `/api/v1/words/{word}/combinations`
+1. **Primary Endpoint**: `/api/v1/words/{word}`
    - Main functionality for finding element combinations
    - Optional support for reversed two-letter symbols
    - Comprehensive examples and error handling
@@ -88,10 +88,10 @@ curl "https://elements.chriswilson.app/api/v1/elements"
 curl "https://elements.chriswilson.app/api/v1/elements/H"
 
 # Find word combinations (main feature)
-curl "https://elements.chriswilson.app/api/v1/words/hero/combinations"
+curl "https://elements.chriswilson.app/api/v1/words/hero"
 
 # Find combinations with reversed symbols
-curl "https://elements.chriswilson.app/api/v1/words/hero/combinations?allow_reversed_symbols=true"
+curl "https://elements.chriswilson.app/api/v1/words/hero?allow_reversed_symbols=true"
 ```
 
 ## Validation

--- a/main.py
+++ b/main.py
@@ -113,7 +113,7 @@ def api_documentation():
         <h2>Endpoints</h2>
         
         <div class="endpoint">
-            <p><span class="method">GET</span> <span class="url">/api/v1/words/{word}/combinations</span></p>
+                            <p><span class="method">GET</span> <span class="url">/api/v1/words/{word}</span></p>
             <p><strong>Primary endpoint:</strong> Find all possible element combinations for a word</p>
             <div class="params">
                 <strong>Path Parameters:</strong><br>
@@ -150,8 +150,8 @@ def api_documentation():
         
         <h2>Examples</h2>
         <ul>
-            <li><code>GET /api/v1/words/hero/combinations</code> → H-Er-O</li>
-            <li><code>GET /api/v1/words/hero/combinations?allow_reversed_symbols=true</code> → Use both normal and reversed symbols (He+eH, etc.)</li>
+                            <li><code>GET /api/v1/words/hero</code> → H-Er-O</li>
+                <li><code>GET /api/v1/words/hero?allow_reversed_symbols=true</code> → Use both normal and reversed symbols (He+eH, etc.)</li>
         </ul>
         
         <h2>Response Format</h2>
@@ -219,7 +219,7 @@ def get_element(symbol):
     return create_success_response(element_data)
 
 # Find word combinations - the main API purpose
-@app.get('/api/v1/words/<word>/combinations')
+@app.get('/api/v1/words/<word>')
 def get_word_combinations(word):
     """Find all possible element combinations for a word"""
     set_json_headers()

--- a/openapi.json
+++ b/openapi.json
@@ -226,7 +226,7 @@
         ]
       }
     },
-    "/api/v1/words/{word}/combinations": {
+    "/api/v1/words/{word}": {
       "get": {
         "summary": "Find Element Combinations for Word",
         "description": "**Primary API endpoint:** Finds all possible chemical element symbol combinations that can spell the given word.\n\nThe word is cleaned to contain only alphabetic characters and combinations are found using element symbols.\nSolutions are sorted by the number of elements used (fewer elements first).\n",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -157,7 +157,7 @@ paths:
       tags:
         - Elements
 
-  /api/v1/words/{word}/combinations:
+  /api/v1/words/{word}:
     get:
       summary: Find Element Combinations for Word
       description: |


### PR DESCRIPTION
Simplify the primary API endpoint by removing the redundant `/combinations` suffix.

The `/combinations` suffix was removed from `GET /api/v1/words/{word}/combinations` to `GET /api/v1/words/{word}`. This change makes the endpoint cleaner and more intuitive, as finding combinations is the sole word-related operation currently supported by the API. No functionality is lost.