### PR TITLE
Update ui for reversed symbols and numbers

### DIFF
--- a/main.py
+++ b/main.py
@@ -336,15 +336,7 @@ def element_words_app():
                 font-weight: 500;
             }
             
-            .reversed-indicator {
-                position: absolute;
-                top: 2px;
-                left: 4px;
-                width: 8px;
-                height: 8px;
-                background: #ed8936;
-                border-radius: 50%;
-            }
+
             
             .api-link {
                 text-align: center;
@@ -529,13 +521,22 @@ def element_words_app():
                     
                     solution.elements.forEach(element => {
                         const reversedClass = element.reversed ? ' reversed' : '';
-                        const reversedIndicator = element.reversed ? '<div class="reversed-indicator"></div>' : '';
+                        
+                        // Transform display for reversed symbols (UI only)
+                        let displaySymbol = element.symbol;
+                        let displayAtomicNumber = element.atomic_number;
+                        
+                        if (element.reversed) {
+                            // Reverse the symbol letter order (e.g., "He" -> "eH")
+                            displaySymbol = element.symbol.split('').reverse().join('');
+                            // Reverse the atomic number digits (e.g., 107 -> 701)
+                            displayAtomicNumber = element.atomic_number.toString().split('').reverse().join('');
+                        }
                         
                         html += `
-                            <div class="element-tile${reversedClass}" title="${element.name} (${element.symbol})${element.reversed ? ' - Reversed symbol' : ''}">
-                                <div class="element-number">${element.atomic_number}</div>
-                                ${reversedIndicator}
-                                <div class="element-symbol">${element.symbol}</div>
+                            <div class="element-tile${reversedClass}" title="${element.name} (${displaySymbol})${element.reversed ? ' - Reversed symbol' : ''}">
+                                <div class="element-number">${displayAtomicNumber}</div>
+                                <div class="element-symbol">${displaySymbol}</div>
                                 <div class="element-name">${element.name}</div>
                             </div>
                         `;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement UI-only display changes for reversed chemical symbols to support game scoring.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
These changes are purely cosmetic for the UI, specifically for elements marked as 'reversed'. The underlying API data (original symbol and atomic number) remains unchanged, as requested, to facilitate future game score calculations.

---

[Open in Web](https://cursor.com/agents?id=bc-2a9698c5-67ae-4d75-a9be-cc00711801d3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2a9698c5-67ae-4d75-a9be-cc00711801d3) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)