### PR TITLE
Simplify go-image svg with gradient background

### DIFF
--- a/static/og-image.svg
+++ b/static/og-image.svg
@@ -1,11 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
-  <rect width="1200" height="630" fill="#667eea"/>
-  <text x="600" y="200" text-anchor="middle" fill="white" font-size="80" font-family="Arial">⚛️ Element Words</text>
-  <text x="600" y="280" text-anchor="middle" fill="white" font-size="40" font-family="Arial">Spell with Chemical Elements</text>
-  <rect x="400" y="350" width="100" height="100" fill="white" stroke="#4a5568" stroke-width="3"/>
-  <text x="450" y="415" text-anchor="middle" fill="#2d3748" font-size="60" font-family="Arial">H</text>
-  <rect x="520" y="350" width="100" height="100" fill="white" stroke="#4a5568" stroke-width="3"/>
-  <text x="570" y="415" text-anchor="middle" fill="#2d3748" font-size="60" font-family="Arial">He</text>
-  <rect x="640" y="350" width="100" height="100" fill="white" stroke="#4a5568" stroke-width="3"/>
-  <text x="690" y="415" text-anchor="middle" fill="#2d3748" font-size="60" font-family="Arial">Li</text>
+  <defs>
+    <linearGradient id="bg-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background with app gradient -->
+  <rect width="1200" height="630" fill="url(#bg-gradient)" />
+  
+  <!-- Atom symbol -->
+  <g fill="white" stroke="white" stroke-width="3" fill-opacity="0.9" transform="translate(600, 450)">
+    <!-- Nucleus (center circle) -->
+    <circle cx="0" cy="0" r="8" fill="white" />
+    
+    <!-- Electron orbits -->
+    <ellipse cx="0" cy="0" rx="50" ry="24" fill="none" stroke-width="4" opacity="0.8" />
+    <ellipse cx="0" cy="0" rx="50" ry="24" fill="none" stroke-width="4" opacity="0.8" transform="rotate(60)" />
+    <ellipse cx="0" cy="0" rx="50" ry="24" fill="none" stroke-width="4" opacity="0.8" transform="rotate(120)" />
+    
+    <!-- Electrons -->
+    <circle cx="50" cy="0" r="5" fill="white" />
+    <circle cx="-30" cy="30" r="5" fill="white" />
+    <circle cx="30" cy="-30" r="5" fill="white" />
+  </g>
+  
+  <!-- Text content -->
+  <text x="600" y="200" text-anchor="middle" fill="white" font-size="80" font-family="Arial, sans-serif" font-weight="bold">Element Words</text>
+  <text x="600" y="280" text-anchor="middle" fill="white" font-size="40" font-family="Arial, sans-serif" opacity="0.9">Spell with Chemical Elements</text>
 </svg>


### PR DESCRIPTION
Simplify `og-image.svg` by applying a gradient background, adding an atomic symbol, and removing example element symbols for a cleaner look.

---

[Open in Web](https://cursor.com/agents?id=bc-77c77ff9-c60c-4ccd-9dfd-794f9e3a983f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-77c77ff9-c60c-4ccd-9dfd-794f9e3a983f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)