### PR TITLE
Review icon link updates in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -938,7 +938,7 @@ def favicon_svg():
 def apple_touch_icon():
     """Serve Apple touch icon"""
     response.headers['Cache-Control'] = 'public, max-age=86400'  # Cache for 1 day
-    return static_file('favicon.svg', root='./static')
+    return static_file('apple-touch-icon.png', root='./static')
 
 # API Documentation endpoint (moved to /api route)
 @app.get('/api')


### PR DESCRIPTION
Fix apple-touch-icon route to serve the correct image.

The route `/apple-touch-icon.png` was incorrectly serving `favicon.svg` instead of `apple-touch-icon.png`. This PR corrects the served file.

---

[Open in Web](https://cursor.com/agents?id=bc-11d90145-a14c-4c47-b981-bf7722c9bd4f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-11d90145-a14c-4c47-b981-bf7722c9bd4f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)