### PR TITLE
Fix share popup icon and title

### DIFF
--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -1,0 +1,37 @@
+{
+  "name": "Element Words",
+  "short_name": "Element Words",
+  "description": "Create words using chemical element symbols from the periodic table",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#667eea",
+  "theme_color": "#667eea",
+  "icons": [
+    {
+      "src": "/static/favicon-16x16.png",
+      "sizes": "16x16",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/favicon-32x32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/favicon-96x96.png",
+      "sizes": "96x96",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/og-image.png",
+      "sizes": "1200x630",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes favicon and title persistence in share dialogs by adding dynamic meta tags and a web manifest.

The favicon was not appearing in Safari's share popup due to missing or improperly configured meta tags and a web manifest. Additionally, the share title was not persisting correctly when sending messages. This PR addresses these by introducing a web manifest, making Open Graph and Twitter meta tags dynamic, and updating them based on the current word, ensuring the favicon appears and the title is correct and persistent during sharing.

---

[Open in Web](https://cursor.com/agents?id=bc-52c9dbcd-74ae-45a1-922e-b093b2d39840) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-52c9dbcd-74ae-45a1-922e-b093b2d39840) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)