### PR TITLE
Verify icon and static image links

### DIFF
--- a/main.py
+++ b/main.py
@@ -129,7 +129,6 @@ def element_words_app():
         <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-180x180-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="196x196" href="/static/android-chrome-196x196.png" />
         <link rel="icon" type="image/png" href="/static/android-chrome-192x192.png" sizes="192x192" type="image/png">
-        <link rel="icon" type="image/png" href="/static/android-chrome-256x256.png" sizes="256x256" type="image/png">
         <link rel="icon" type="image/png" href="/static/android-chrome-384x384.png" sizes="384x384" type="image/png">
         <link rel="icon" type="image/png" href="/static/android-chrome-512x512.png" sizes="512x512" type="image/png">
         

--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -32,19 +32,19 @@
       "purpose": "any"
     },
     {
-      "src": "/apple-touch-icon.png",
-      "sizes": "180x180",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/static/apple-touch-icon.png",
+      "src": "/static/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/static/apple-touch-icon.png",
+      "src": "/static/android-chrome-384x384.png",
+      "sizes": "384x384",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/static/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes broken favicon link and corrects web manifest icon references for improved cross-platform support.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `main.py` change removes a reference to an `android-chrome-256x256.png` file that did not exist, preventing a 404 error. The `site.webmanifest` changes correct instances where `apple-touch-icon.png` was incorrectly referenced for Android Chrome icon sizes and ensures consistent `/static/` paths for all icons.

---

[Open in Web](https://cursor.com/agents?id=bc-217ae0cf-85f2-4e5d-a803-5cbe5521b708) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-217ae0cf-85f2-4e5d-a803-5cbe5521b708) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)