### PR TITLE
Update share title with searched word

### DIFF
--- a/main.py
+++ b/main.py
@@ -799,10 +799,17 @@ def element_words_app():
             function shareCurrentState() {
                 const currentURL = window.location.href;
                 const word = wordInput.value.trim();
-                const shareTitle = document.title; // Use the current page title
+                
+                // Construct the title dynamically to ensure it matches the current state
+                const baseTitle = "Element Words";
+                const shareTitle = word ? `${baseTitle} - ${word.toUpperCase()}` : baseTitle;
+                
                 const shareText = word ? 
                     `Check out "${word.toUpperCase()}" spelled using chemical element symbols!` : 
                     'Check out this word made from chemical element symbols!';
+                
+                // Ensure meta tags are updated before sharing (for share sheet preview)
+                updatePageMetadata(word);
                 
                 // Try to use the Web Share API if available (modern browsers, especially mobile)
                 if (navigator.share) {


### PR DESCRIPTION
Dynamically construct share sheet title and force metadata update to ensure it reflects the current word.

The Web Share API on some platforms was reading a stale or cached `document.title` or Open Graph meta tag value, leading to an incorrect title in the share sheet. This fix ensures the title is explicitly generated from the current state and metadata is refreshed immediately before the share operation.

---

[Open in Web](https://cursor.com/agents?id=bc-5c6992eb-6a7d-4683-afaf-ce6b7fe847b1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5c6992eb-6a7d-4683-afaf-ce6b7fe847b1) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)