### PR TITLE
Fix share sheet title and image

### DIFF
--- a/static/README.md
+++ b/static/README.md
@@ -8,10 +8,10 @@ This directory contains static assets for the Element Words application.
 - `favicon.svg` - SVG favicon with atom emoji
 - `og-image.svg` - Open Graph image for social media sharing (1200x630)
 
-### PNG Files (Need to be created)
-- `favicon-16x16.png` - 16x16 PNG favicon (placeholder)
-- `favicon-32x32.png` - 32x32 PNG favicon (placeholder)
-- `og-image.png` - 1200x630 PNG version for social media (placeholder)
+### PNG Files (Ready to use)
+- `favicon-16x16.png` - 16x16 PNG favicon
+- `favicon-32x32.png` - 32x32 PNG favicon
+- `android-chrome-512x512.png` - 512x512 PNG used for Open Graph sharing (high-res favicon style)
 
 ## Converting SVG to PNG
 
@@ -33,21 +33,21 @@ To create the PNG files, you can use:
 # Using ImageMagick
 convert favicon.svg -resize 16x16 favicon-16x16.png
 convert favicon.svg -resize 32x32 favicon-32x32.png
-convert og-image.svg -resize 1200x630 og-image.png
+convert favicon.svg -resize 512x512 android-chrome-512x512.png
 
 # Using Inkscape
 inkscape favicon.svg --export-png=favicon-16x16.png --export-width=16 --export-height=16
 inkscape favicon.svg --export-png=favicon-32x32.png --export-width=32 --export-height=32
-inkscape og-image.svg --export-png=og-image.png --export-width=1200 --export-height=630
+inkscape favicon.svg --export-png=android-chrome-512x512.png --export-width=512 --export-height=512
 ```
 
 ## Important Notes
 
 1. **Update Domain URLs**: In `main.py`, replace `https://your-domain.com` with your actual domain name in the Open Graph meta tags.
 
-2. **Social Media Compatibility**: PNG files are more widely supported by social media platforms than SVG files.
+2. **Social Media Compatibility**: PNG files are more widely supported by social media platforms than SVG files. We now use a 512x512 favicon-style image for Open Graph sharing instead of the traditional large banner format.
 
-3. **File Sizes**: Keep PNG files optimized for web use to ensure fast loading times.
+3. **File Sizes**: The 512x512 PNG is optimized for web use (under 5KB) ensuring fast loading times while maintaining high quality for sharing previews.
 
 4. **Testing**: Test social media sharing after creating the PNG files using tools like:
    - [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)


### PR DESCRIPTION
Ensure consistent share sheet titles and optimize the Open Graph image.

The page title was not reliably appearing in share sheet messages, particularly when a specific word was in the URL, due to timing issues with JavaScript updates. This PR introduces explicit meta tag updates and a small delay before triggering the share API to ensure the correct title ("Element Words - <WORD>") is picked up. Additionally, the large `og-image.png` (816KB) has been replaced with a smaller, high-resolution favicon-style image (`android-chrome-512x512.png`, 4.9KB) to improve performance and provide the requested visual style.

---

[Open in Web](https://cursor.com/agents?id=bc-34e92a5a-4bdb-4d93-bb6a-858c290787c0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-34e92a5a-4bdb-4d93-bb6a-858c290787c0) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)